### PR TITLE
feat: support for springboot-3.0

### DIFF
--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.casbin.casdoor.config.CasdoorAutoConfigure


### PR DESCRIPTION
Springboot-3.0 has abandoned spring.factories automatic assembly.
[details](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files)

Fix: https://github.com/casdoor/casdoor-spring-boot-starter/issues/26