### PR TITLE
feat: update Casdoor Java SDK to version 1.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.casbin</groupId>
             <artifactId>casdoor-java-sdk</artifactId>
-            <version>1.33.0</version>
+            <version>1.34.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates the Casdoor Java SDK dependency in the pom.xml file from version 1.33.0 to version 1.34.0.

### Reason for Update
Version 1.33.0 of the Casdoor Java SDK had an issue with the Buy Product API, which was not functioning correctly. The issue has been resolved in version 1.34.0, as confirmed by the Casdoor team.

### Changes Made
- Updated the `casdoor-java-sdk` dependency in the `pom.xml` file to version 1.34.0.

### Testing
- Verified that the Buy Product API now works as expected with version 1.34.0.
- Ran existing tests to ensure no other functionality is broken by the update.

### Impact
This update ensures that users of the Spring Boot Casdoor SDK can utilize the Buy Product API without encountering the previously reported issue.